### PR TITLE
Update to Svelte v3 -> v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "eslint": "^7.32.0",
     "eslint-plugin-square": "^20.0.2",
     "jest": "^27.2.4",
-    "svelte": "^3.0.0",
+    "svelte": "^4.0.0",
     "ts-jest": "^27.0.5",
     "ts-jest-resolver": "^2.0.1",
     "typescript": "^4.5.5"
@@ -50,7 +50,7 @@
     "cookie-storage": "^6.1.0"
   },
   "peerDependencies": {
-    "svelte": "^3.0.0"
+    "svelte": "^4.0.0"
   },
   "license": "ISC",
   "author": "Square",

--- a/src/standard-stores/index.ts
+++ b/src/standard-stores/index.ts
@@ -133,14 +133,20 @@ export const writable = <T>(
     loadPromise = Promise.resolve(value);
   };
 
-  const startFunction: StartStopNotifier<T> = (set: Subscriber<T>) => {
+  const startFunction: StartStopNotifier<T> = (
+    set: Subscriber<T>,
+    update: (fn: Updater<T>) => void
+  ) => {
     const customSet = (value: T) => {
       set(value);
       updateLoadPromise(value);
     };
+    const customUpdate = (fn: Updater<T>) => {
+      update(fn);
+    };
     // intercept the `set` function being passed to the provided start function
     // instead provide our own `set` which also updates the load promise.
-    return start(customSet);
+    return start(customSet, customUpdate);
   };
 
   const thisStore = vanillaWritable(value, start && startFunction);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "types": ["node", "jest"],
+    "types": ["jest"],
     "declaration": true,
     "outDir": "./lib",
     "sourceMap": true,


### PR DESCRIPTION
- StartStopNotifier now takes two arguments instead of one.
- Removed node types to avoid error related to AbortSignal declaration